### PR TITLE
chore(repo move): adapt DockerHub build to repo move

### DIFF
--- a/library/bonita
+++ b/library/bonita
@@ -1,24 +1,23 @@
-Maintainers: Jérémy Jacquier-Roux <jeremy.jacquier-roux@bonitasoft.org> (@JeremJR),
-             Truc Nguyen <truc.nguyen@bonitasoft.org> (@tnguyen1),
-             Laurent Leseigneur <laurent.leseigneur@bonitasoft.org> (@laurentleseigneur),
-             Baptiste Mesta <baptiste.mesta@bonitasoft.org> (@baptistemesta),
+Maintainers: Baptiste Mesta <baptiste.mesta@bonitasoft.org> (@baptistemesta),
              Danila Mazour <danila.mazour@bonitasoft.org> (@danila-m),
              Emmanuel Duchastenier <emmanuel.duchastenier@bonitasoft.org> (@educhastenier),
-             Pascal Garcia <pascal.garcia@bonitasoft.org> (@passga)
-GitRepo: https://github.com/Bonitasoft-Community/docker_bonita.git
+             Pascal Garcia <pascal.garcia@bonitasoft.org> (@passga),
+             Anthony Birembaut <anthony.birembaut@bonitasoft.org> (@abirembaut),
+             Dumitru Corini <dumitru.corini@bonitasoft.org> (@DumitruCorini)
+Architectures: amd64, arm64v8, ppc64le
 
 Tags: 7.9.5, 7.9
-Architectures: amd64, arm64v8, ppc64le
+GitRepo: https://github.com/Bonitasoft-Community/docker_bonita.git
 GitCommit: b58b05d989055ca3521fc92211d10ff640b4028f
 Directory: 7.9
 
 Tags: 7.10.6, 7.10
-Architectures: amd64, arm64v8, ppc64le
+GitRepo: https://github.com/Bonitasoft-Community/docker_bonita.git
 GitCommit: e6f9f1a5e57c35bbd833c9441a639f326dffb7d5
 Directory: 7.10
 
-Tags: 7.11.2, 7.11, latest
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: e6f9f1a5e57c35bbd833c9441a639f326dffb7d5
-Directory: 7.11
+Tags: 7.11.3, 7.11, latest
+GitRepo: https://github.com/bonitasoft/bonita-distrib.git
+GitCommit: 39f39f028c344311e8f35c7e98b1c18051f277f6
+Directory: docker
 


### PR DESCRIPTION
New repo is bonita-distrib (community version)

! Not ready to merge like this yet !